### PR TITLE
ユーザー登録後とログイン後のパス変更

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,5 @@
 class HomeController < ApplicationController
+  before_action :require_login
   def index
   end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -8,7 +8,6 @@ class UserSessionsController < ApplicationController
     @user = login(params[:email], params[:password])
 
     if @user
-      auto_login(@user)
       redirect_to home_path, notice: "ログインしました"
     else
       flash.now[:alert] = "ログインに失敗しました"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,8 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
 
     if @user.save
-      redirect_to root_path,  notice: "アカウントを作成しました"
+      auto_login(@user)
+      redirect_to home_path,  notice: "アカウントを作成しました"
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <div class="navbar bg-purple-300">
   <div class="flex-1">
-    <%= link_to root_path, class: "btn btn-ghost text-xl" do %>
+    <%= link_to home_path, class: "btn btn-ghost text-xl" do %>
     Travel Starter
     <% end %>
   </div>


### PR DESCRIPTION
Closes #95 

## 概要
ユーザー登録後とログイン後にhomeに遷移する様に修正。
ユーザー登録後はオートログインでhomeへ遷移
ヘッダーのアイコンを押すとログイン中はホーム画面に遷移する






