### PR TITLE
バリデーションエラーメッセージの設定

### DIFF
--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div id= 'error_explanation' class= 'alert alert-danger'>
+    <ul class="mb-0">
+      <% object.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,6 +3,7 @@
     <div class="flex flex-col justify-center items-center min-h-screen">
       <h1 class="text-3xl font-bold mb-6">新規ユーザー登録</h1>
       <%= form_with model: @user, local: true do |form| %>
+        <%= render 'shared/error_messages', object: form.object %>
         <div class="mb-8">
           <%= form.label :name, "名前", class: "block text-lg font-medium text-gray-700"  %>
           <%= form.text_field :name, placeholder: "10文字以下", class: "mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md h-12 p-2" %>


### PR DESCRIPTION

Closes #97 

## 概要
バリデーションエラーが起きた時にメッセージが出る様に設定

## 実施内容
app/views/shared/_error_messages.html.erb　に以下設定
```
<% if object.errors.any? %>
  <div id= 'error_explanation' class= 'alert alert-danger'>
    <ul class="mb-0">
      <% object.errors.full_messages.each do |message| %>
        <li><%= message %></li>
      <% end %>
    </ul>
  </div>
<% end %>
```
- ユーザー登録用viewに呼び出し
```
<%= render 'shared/error_messages', object: form.object %>
```

## 備考
日本語化対応は本リリース