### PR TITLE
AWS S3の連携を実施

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@
 /node_modules
 .DS_Store
 /vendor/bundle
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,9 @@ gem "bootsnap", require: false
 
 gem 'sorcery'
 gem 'carrierwave', '~> 3.0'
+gem 'dotenv', groups: [:development, :test]
+gem 'fog-aws'
+
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,8 +109,10 @@ GEM
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    dotenv (3.1.2)
     drb (2.2.1)
     erubi (1.13.0)
+    excon (0.111.0)
     faraday (2.9.2)
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
@@ -121,6 +123,22 @@ GEM
     ffi (1.17.0-x86-linux-gnu)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
+    fog-aws (3.24.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+    fog-core (2.4.0)
+      builder
+      excon (~> 0.71)
+      formatador (>= 0.2, < 2.0)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.4)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (1.1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -151,10 +169,14 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mime-types (3.5.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.0702)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.24.1)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
     mutex_m (0.2.0)
@@ -313,6 +335,8 @@ DEPENDENCIES
   carrierwave (~> 3.0)
   cssbundling-rails
   debug
+  dotenv
+  fog-aws
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/app/uploaders/photo_uploader.rb
+++ b/app/uploaders/photo_uploader.rb
@@ -4,8 +4,11 @@ class PhotoUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  if Rails.env.production?
+    storage :fog
+  else
+    storage :file
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,22 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+  if Rails.env.production?
+    config.storage :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_directory  = ENV['S3_BUCKET_NAME']
+    config.fog_public = false
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['S3_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['S3_SECRET_ACCESS_KEY'],
+      region: ENV['S3_REGION'],
+      path_style: true
+    }
+  else
+    config.storage :file
+    config.enable_processing = false if Rails.env.test?
+  end
+end


### PR DESCRIPTION
Closes #108

AWS連携をして、carrierwaveで投稿した画像が永続的に保存できるようにする。