### PR TITLE
fix: N+1対策としてgem bulletを導入 #113

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+  gem 'bullet'
 
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,9 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.3.0)
+    bullet (7.2.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capybara (3.40.0)
       addressable
       matrix
@@ -305,6 +308,7 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uniform_notifier (1.16.0)
     uri (0.13.0)
     version_gem (1.1.4)
     web-console (4.2.1)
@@ -331,6 +335,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  bullet
   capybara
   carrierwave (~> 3.0)
   cssbundling-rails

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -39,8 +39,10 @@ class TripsController < ApplicationController
 
   def update
     if @trip.update(trip_params)  # 旅行情報を更新
-      @trip.todos.destroy_all  # 旅行に紐づくToDoを全て削除
-      add_default_todos(@trip)  # default_todos_for メソッドを使って旅行先に応じたデフォルトのToDoを追加
+      ActiveRecord::Base.transaction do
+        @trip.todos.destroy_all  # 旅行に紐づくToDoを全て削除
+        add_default_todos(@trip)  # default_todos_for メソッドを使って旅行先に応じたデフォルトのToDoを追加
+      end
       redirect_to @trip, notice: "旅行情報が更新されました"
     else
       render :edit

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,15 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time


### PR DESCRIPTION


Closes #113 

## 概要
N+1問題対策を実施

## 実施内容
- gem bulletの導入
- trips controllerのupdateアクションの編集 。トランザクションの導入
```
def update
    if @trip.update(trip_params)  # 旅行情報を更新
      ActiveRecord::Base.transaction do
        @trip.todos.destroy_all  # 旅行に紐づくToDoを全て削除
        add_default_todos(@trip)  # default_todos_for メソッドを使って旅行先に応じたデフォルトのToDoを追加
      end
      redirect_to @trip, notice: "旅行情報が更新されました"
    else
      render :edit
    end
  end
```
