### PR TITLE
リダイレクトURLの修正とhomeの連携ボタンを編集  #171

### DIFF
--- a/app/controllers/line_auth_controller.rb
+++ b/app/controllers/line_auth_controller.rb
@@ -23,15 +23,16 @@ class LineAuthController < ApplicationController
     redirect_uri = line_auth_callback_url
     state = SecureRandom.hex(10) #CSRF対策のためのstateパラメータ
     scope = "profile openid" #プロフィール情報を取得するためのスコープ
+    bot_prompt = "aggressive" #LINEログイン画面でのユーザーへのプロンプト表示
 
-    "https://access.line.me/oauth2/v2.1/authorize?response_type=code&client_id=#{client_id}&redirect_uri=#{redirect_uri}&state=#{state}&scope=#{scope}"
+    "https://access.line.me/oauth2/v2.1/authorize?response_type=code&client_id=#{client_id}&redirect_uri=#{redirect_uri}&state=#{state}&scope=#{scope}&bot_prompt=#{bot_prompt}"
   end
 
 
   def get_line_token(code) #認証コードを使ってアクセストークンを取得
     client_id = ENV['LINE_LOGIN_CHANNEL_ID']
     client_secret = ENV['LINE_LOGIN_CHANNEL_SECRET']
-    redirect_uri = callback_line_auth_url
+    redirect_uri = line_auth_callback_url
 
     response = RestClient.post("https://api.line.me/oauth2/v2.1/token", {
       "grant_type" => "authorization_code",

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -52,23 +52,11 @@
 
     <div class="card glass w-full mt-6">
       <div class="mt-6 text-center">
-        <p>友だち追加をすると<br>
+        <p>LINEと連携すると<br>
         出発予定日の1週間前から<br>
         メッセージが届きます！</p>
-      </div>
-
-      <div class="flex justify-center mt-8">
-        <div class="w-full flex justify-center">
-          <%= link_to "https://lin.ee/t427Y3k", class: "w-32" do %>
-            <%= image_tag("https://scdn.line-apps.com/n/line_add_friends/btn/ja.png", alt: "友だち追加", class: "w-full h-auto", target: :_blank) %>
-          <% end %>
-        </div>
-      </div>
-      <!-- LINE連携手順の説明 -->
-      <div class="mt-6 text-center">
-        <p>LINEアカウントと連携する</p>
         <%= link_to line_link_path, method: :get do %>
-          <%= image_tag "btn_login.png", class: "w-32 mx-auto mt-4" %>
+          <%= image_tag "btn_login.png", class: "w-32 mx-auto mt-4 mb-4" %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION

Closes #171 

## 概要
- リダイレクト先URLの修正
- homeにある既存のLINE友だち追加ボタンを削除
