### PR TITLE
dotenvを読み込むように明示的に表示

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require_relative "boot"
 
 require "rails/all"
+require 'dotenv/load'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
本番環境でのメール未送信エラー解消に向けて.envを読み込むgemの明示的記載を行いました。