### PR TITLE
dotenv-railsに変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem "bootsnap", require: false
 
 gem 'sorcery'
 gem 'carrierwave', '~> 3.0'
-gem 'dotenv', groups: [:development, :test]
+gem 'dotenv-rails', groups: [:development, :test]
 gem 'fog-aws'
 gem 'config'
 gem 'rails-i18n', '~> 7.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,9 @@ GEM
       reline (>= 0.3.8)
     deep_merge (1.2.2)
     dotenv (3.1.2)
+    dotenv-rails (3.1.2)
+      dotenv (= 3.1.2)
+      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.0)
     event_stream_parser (1.0.0)
@@ -373,7 +376,7 @@ DEPENDENCIES
   config
   cssbundling-rails
   debug
-  dotenv
+  dotenv-rails
   fog-aws
   httparty (~> 0.22.0)
   jbuilder


### PR DESCRIPTION

- gem dotenvからgem dotenv-railsに変更し、本番環境でも.env ファイルに定義した環境変数を本番環境や開発環境などの全ての環境で読み込めるようにしました