### PR TITLE
マイページを作成し、ユーザー名とアドレスを変更できるように実装 #71, #79, #83, #139

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,17 +18,28 @@ class UsersController < ApplicationController
     end
   end
 
+  def show
+    @user = current_user
+  end
+
   def edit
-    @user = User.find(params[:id])
+    @user = current_user
   end
 
   def update
-    @user = User.find(params[:id])
+    @user = current_user
     if @user.update(user_params)
       redirect_to @user, notice: 'アカウント情報が更新されました。'
     else
       render :edit
     end
+  end
+
+  def destroy
+    @user = current_user
+    @user.destroy
+    reset_session
+    redirect_to root_path, status: :see_other, notice: 'アカウントを削除しました。'
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,8 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
 
   attr_accessor :password_confirmation
-  has_many :authenticates, dependent: :destroy
-  accepts_nested_attributes_for :authenticates
+  has_many :authentications, dependent: :destroy
+  accepts_nested_attributes_for :authentications
   has_many :trips, dependent: :destroy
   has_many :todos, through: :trips
   has_one :passport, dependent: :destroy

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,6 +15,8 @@
         <li><%= link_to "FLIGHT", flights_path %></li>
         <li><%= link_to "AI CHATBOT", chatbots_ask_path %></li>
         <li><%= link_to "ホーム", home_path %></li>
+        <li><%= link_to "マイページ", user_path(current_user) %></li>
+        <li><%= link_to "アカウント削除", user_path(current_user), data: { turbo_method: "delete", turbo_confirm: '本当に退会しますか？'} %></li>
         <li><%= button_to "ログアウト", logout_path, method: :delete %></li>
       </ul>
     </details>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,0 +1,23 @@
+<%= form_with(model: user) do |form| %>
+  <% if user.errors.any? %>
+    <div style="color: red;">
+      <h2><%= pluralize(user.errors.count, "error") %> prohibited this user from being saved:</h2>
+      <ul>
+        <% user.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <div class="mb-8 w-3/5 sm:w-4/5 md:w-full mx-auto">
+    <%= form.label :name, "名前", class: "block text-base font-bold text-gray-700 text-left" %>
+    <%= form.text_field :name, placeholder: "10文字以下", class: "w-3/5 sm:w-4/5 md:w-full mx-auto mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md h-12 p-2" %>
+  </div>
+  <div class="mb-8 w-3/5 sm:w-4/5 md:w-full mx-auto">
+    <%= form.label :email, "メールアドレス", class: "block text-base font-bold text-gray-700 text-left" %>
+    <%= form.email_field :email, placeholder: "メールアドレスを入力", class: "w-3/5 sm:w-4/5 md:w-full mx-auto mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md h-12 p-2" %>
+  </div>
+  <div class="mb-8 flex justify-center w-3/5 sm:w-4/5 md:w-full mx-auto flex-row space-x-4">
+    <%= form.submit "更新", class: "btn btn-accent rounded mt-4 w-80" %>
+  </div>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,12 @@
+<div class="flex flex-col justify-center items-center min-h-screen">
+  <h1 class="text-2xl sm:text-3xl font-bold mb-10 mt-20 flex justify-center">プロフィール編集</h1>
+  <div class="flex flex-wrap justify-center text-center">
+    <div class="card w-96 bg-base-100 shadow-xl mb-10">
+      <div class="card-body items-center text-center">
+
+        <%= render "form", user: @user %>
+
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -5,19 +5,19 @@
       <%= form_with model: @user, local: true do |form| %>
       <%= render 'shared/error_messages', object: form.object %>
         <div class="mb-8 w-3/5 sm:w-4/5 md:w-full mx-auto">
-          <%= form.label :name, "名前", class: "block text-lg font-medium text-gray-700"  %>
+          <%= form.label :name, "名前", class: "block text-lg font-medium text-gray-700 after:content-['*'] after:ml-0.5 after:text-red-500" %>
           <%= form.text_field :name, placeholder: "10文字以下", class: "w-3/5 sm:w-4/5 md:w-full mx-auto mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md h-12 p-2" %>
         </div>
         <div class="mb-8 w-3/5 sm:w-4/5 md:w-full mx-auto">
-          <%= form.label :email, "メールアドレス", class: "block text-lg font-medium text-gray-700" %>
+          <%= form.label :email, "メールアドレス", class: "block text-lg font-medium text-gray-700 after:content-['*'] after:ml-0.5 after:text-red-500" %>
           <%= form.email_field :email, placeholder: "メールアドレスを入力", class: "w-3/5 sm:w-4/5 md:w-full mx-auto mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md h-12 p-2" %>
         </div>
         <div class="mb-8 w-3/5 sm:w-4/5 md:w-full mx-auto">
-          <%= form.label :password, "パスワード", class: "block text-lg font-medium text-gray-700" %>
+          <%= form.label :password, "パスワード", class: "block text-lg font-medium text-gray-700 after:content-['*'] after:ml-0.5 after:text-red-500" %>
           <%= form.password_field :password, placeholder: "4文字以上8文字以下", class: "w-3/5 sm:w-4/5 md:w-full mx-auto mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md h-12 p-2" %>
         </div>
         <div class="mb-8 w-3/5 sm:w-4/5 md:w-full mx-auto">
-          <%= form.label :password_confirmation, "パスワード（確認）", class: "block text-lg font-medium text-gray-700" %>
+          <%= form.label :password_confirmation, "パスワード（確認）", class: "block text-lg font-medium text-gray-700 after:content-['*'] after:ml-0.5 after:text-red-500" %>
           <%= form.password_field :password_confirmation, placeholder: "パスワードをもう一度", class: "w-3/5 sm:w-4/5 md:w-full mx-auto mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md h-12 p-2" %>
         </div>
         <div class="mb-8 flex justify-center w-3/5 sm:w-4/5 md:w-full mx-auto">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,17 @@
+<div class="flex flex-col justify-center items-center min-h-screen">
+  <h1 class="text-2xl sm:text-3xl font-bold mb-10 mt-20 flex justify-center"><%= current_user.name %>さんのプロフィール</h1>
+  <div class="flex flex-wrap justify-center text-center">
+    <div class="card w-96 bg-base-100 shadow-xl mb-10">
+      <div class="card-body items-center text-center">
+        <h2 class="card-title mt-4"><%= current_user.name %></h2>
+        <p class="text-sm">メールアドレス: <%= current_user.email %></p>
+        <div class="card-actions justify-center">
+          <%= link_to "編集", edit_user_path(@user), class: "btn btn-accent rounded shadow-lg mt-6 w-80" %>
+        </div>
+        <div class="card-actions justify-center">
+          <%= link_to "パスワード変更はこちら", new_password_reset_path, class: "btn btn-accent rounded shadow-lg mt-6 w-80" %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   root 'static_pages#top'
-  resources :users
+  resources :users, only: [:new, :create, :show, :edit, :update, :destroy]
   resources :trips do
     member do
       post 'add_todo'


### PR DESCRIPTION

Closes #71, #79, #83, #139

## 概要
マイページの作成
アカウント削除機能の実装

## 実施内容
- マイページを作成し、ユーザー名とメールアドレスを変更できるようにした。
- パスワードリセットは直接ではなく、パスワードリセット申請を通して変更するように表示

