### PR TITLE
Googleログインの修正 #262

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -4,28 +4,37 @@ class OauthsController < ApplicationController
   skip_before_action :require_login
 
   def oauth
-    Rails.logger.debug "OAuth Provider: #{auth_params[:provider]}"
+    # 指定したプロバイダの認証ページにリダイレクト
     login_at(auth_params[:provider])
   end
 
   def callback
     provider = auth_params[:provider]
-    Rails.logger.debug "Callback Provider: #{provider}"
-    Rails.logger.debug "Redirect URI: #{ENV['GOOGLE_CALLBACK_URL']}"
-    if (@user = login_from(provider))
-      puts "Logged in from provider: #{@user.inspect}" # デバッグ出力
-      reset_session
-      auto_login(@user)
-      redirect_to home_path, notice: 'Googleアカウントでログインしました'
+
+    #　既存のユーザーをプロバイダ情報を元に検索し、見つかればログイン
+    if (@user = login_from(auth_params[:provider]))
+      flash[:notice] = "Googleアカウントでログインしました"
+      redirect_to home_path
     else
       begin
-        Rails.logger.debug 'User not found, signing up'
-        sign_up_and_login_from(provider)
-        redirect_to home_path, notice: 'Googleアカウントでログインしました'
+
+        #Googleアカウントのメールアドレスと一致する既存のユーザーがいるか検索
+        sorcery_fetch_user_hash(provider)
+        existing_user = User.find_by(email: @user_hash[:user_info][:email])
+
+        if existing_user
+        # 既存ユーザーにGoogleプロバイダ情報を追加
+          existing_user.authentications.create(provider: provider, uid: @user_hash[:uid].to_s)
+          auto_login(existing_user)
+          redirect_to home_path, notice: 'Googleアカウントでログインしました'
+        else
+          # 新規ユーザーを作成し、Googleプロバイダ情報を追加
+          sign_up_and_login_from(provider)
+          redirect_to home_path, notice: 'Googleアカウントでログインしました'
+        end
+
       rescue StandardError => e
-        Rails.logger.error "Google認証に失敗しました: #{e.message}"
-        Rails.logger.error "バックトレース: #{e.backtrace.join("\n")}"
-        redirect_to root_path, alert: 'Google認証に失敗しました'
+        redirect_to login_path, alert: 'Google認証に失敗しました'
       end
     end
   end
@@ -38,6 +47,7 @@ class OauthsController < ApplicationController
 
   def sign_up_and_login_from(provider)
     @user = create_from(provider)
+    reset_session
     auto_login(@user)
   end
 end


### PR DESCRIPTION
Closes #262 

## 概要
gmailで登録した既存ユーザーがGoogleログインできるようにする

## 実施内容
Oauthコントローラーを修正し、紐付け作業を実施しました。

