### PR TITLE
#283 トップページのUI変更

### DIFF
--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -14,27 +14,27 @@
     <p class="text animate-nudge-text mt-2">Scroll</p>
 </div>
 
-<div class="flex flex-col justify-start items-start py-20 mt-10" style="padding-left: 3rem;">
-<h1 class="text-xl sm:text-2xl font-bold mb-6 text-left">
-  <span class="font-caveat" style="font-family: 'Caveat', cursive;">Travel Starter</span>
-  <span class="font-zen" style="font-family: 'Zen Maru Gothic', serif;">とは？</span>
-</h1>
-  <p class="text-left text-xs sm:text-base" style="line-height: 1.6;">
-  「海外旅行に行ってみたい！でも、何を準備すればいいのかわからない…」<br>
-  そんなふうに感じたことはありませんか？<br>
-  Travel Starterは、あなたの旅行準備をサポートするアプリです。<br>
-  便利なTO DOチェックリストやフライト情報を通じて、旅行前の不安を解消し、<br>
-  安心して旅立てるようお手伝いします。<br>
-  さあ、一緒に旅の準備を始めましょう！<br>
+<div class="flex flex-col justify-center items-center min-h-screen py-20 mt-10" style="padding-left: 3rem;">
+  <h1 class="text-xl sm:text-2xl font-bold mb-6 text-center">
+    <span class="font-caveat" style="font-family: 'Caveat', cursive;">Travel Starter</span>
+    <span class="font-zen" style="font-family: 'Zen Maru Gothic', serif;">とは？</span>
+  </h1>
+  <p class="text-center text-xs sm:text-base" style="line-height: 1.6;">
+    「海外旅行に行ってみたい！でも、何を準備すればいいのかわからない…」<br>
+    そんなふうに感じたことはありませんか？<br>
+    Travel Starterは、あなたの旅行準備をサポートするアプリです。<br>
+    便利なTO DOチェックリストやフライト情報を通じて、旅行前の不安を解消し、<br>
+    安心して旅立てるようお手伝いします。<br>
+    さあ、一緒に旅の準備を始めましょう！<br>
   </p>
 </div>
 
-<div class="flex flex-col justify-start items-start py-6" style="padding-left: 3rem;">
+<div class="flex flex-col justify-center items-center py-6" style="padding-left: 3rem;">
 <h1 class="text-xl sm:text-2xl font-bold mb-6">
   <span class="font-caveat" style="font-family: 'Caveat', cursive;">Travel Starter</span>
   <span class="font-zen" style="font-family: 'Zen Maru Gothic', serif;">でできること</span>
 </h1>
-<p class="text-left text-xs sm:text-base" style="line-height: 1.6;">
+<p class="text-center text-xs sm:text-base" style="line-height: 1.6;">
   横にスクロールができます▶︎<br>
 </p>
 


### PR DESCRIPTION

Closes #283 

## 概要
トップページの説明書きをタイトルに合わせて中央に配置

## 実施内容
トップページの説明書きをタイトルに合わせて中央に配置。目線が真下に行くようにしました。
